### PR TITLE
Handle untrainable cards

### DIFF
--- a/commands/card.py
+++ b/commands/card.py
@@ -56,14 +56,16 @@ class CardCog(commands.Cog):
 
             card_image_normal = None
             card_image_after = None
+            can_train = True
             try:
                 card_image_normal = await card.get_card_async('normal')
-            except bestdori.exceptions.NotExistException:
+            except (bestdori.exceptions.NotExistException, bestdori.exceptions.AssetsException):
                 card_image_normal = None
             try:
                 card_image_after = await card.get_card_async('after_training')
-            except bestdori.exceptions.NotExistException:
+            except (bestdori.exceptions.NotExistException, bestdori.exceptions.AssetsException):
                 card_image_after = None
+                can_train = False
 
             title_text = get_text(lang, "card", "EMBED_TITLE", CARD_ID=card_id)
             embed = discord.Embed(title=title_text, color=0x00ff00)
@@ -93,6 +95,13 @@ class CardCog(commands.Cog):
                 embed.add_field(
                     name=get_text(lang, "card", "FIELD_CHARACTER"),
                     value="N/A",
+                    inline=False
+                )
+
+            if not can_train:
+                embed.add_field(
+                    name=get_text(lang, "card", "FIELD_TRAINING"),
+                    value=get_text(lang, "card", "NOT_TRAINABLE"),
                     inline=False
                 )
 

--- a/textmap_CHS.json
+++ b/textmap_CHS.json
@@ -4,6 +4,8 @@
     "EMBED_TITLE": "卡面 #{CARD_ID}",
     "FIELD_TITLE": "标题",
     "FIELD_CHARACTER": "角色",
+    "FIELD_TRAINING": "特训",
+    "NOT_TRAINABLE": "此卡没有特训立绘。",
     "NOT_FOUND": "ID为{CARD_ID}的卡面不存在！",
     "ERROR": "获取卡面信息时出错，请稍后再试\n{ERROR}"
   },

--- a/textmap_CHT.json
+++ b/textmap_CHT.json
@@ -4,6 +4,8 @@
     "EMBED_TITLE": "卡面 #{CARD_ID}",
     "FIELD_TITLE": "標題",
     "FIELD_CHARACTER": "角色",
+    "FIELD_TRAINING": "特訓",
+    "NOT_TRAINABLE": "此卡沒有特訓立繪。",
     "NOT_FOUND": "ID為{CARD_ID}的卡面不存在！",
     "ERROR": "獲取卡面資訊時出錯，請稍後再試\n{ERROR}"
   },

--- a/textmap_ENG.json
+++ b/textmap_ENG.json
@@ -4,6 +4,8 @@
     "EMBED_TITLE": "Card #{CARD_ID}",
     "FIELD_TITLE": "Title",
     "FIELD_CHARACTER": "Character",
+    "FIELD_TRAINING": "Training",
+    "NOT_TRAINABLE": "This card cannot be trained.",
     "NOT_FOUND": "Card with ID {CARD_ID} does not exist.",
     "ERROR": "Error fetching card data, please try again later\n{ERROR}"
   },

--- a/textmap_JPN.json
+++ b/textmap_JPN.json
@@ -4,6 +4,8 @@
     "EMBED_TITLE": "カード #{CARD_ID}",
     "FIELD_TITLE": "タイトル",
     "FIELD_CHARACTER": "キャラクター",
+    "FIELD_TRAINING": "特訓",
+    "NOT_TRAINABLE": "このカードには特訓後イラストがありません。",
     "NOT_FOUND": "IDが{CARD_ID}のカードは存在しません。",
     "ERROR": "カード情報の取得中にエラーが発生しました。後ほどお試しください\n{ERROR}"
   },

--- a/textmap_KOR.json
+++ b/textmap_KOR.json
@@ -4,6 +4,8 @@
     "EMBED_TITLE": "카드 #{CARD_ID}",
     "FIELD_TITLE": "제목",
     "FIELD_CHARACTER": "캐릭터",
+    "FIELD_TRAINING": "특훈",
+    "NOT_TRAINABLE": "이 카드는 특훈 일러스트가 없습니다.",
     "NOT_FOUND": "ID가 {CARD_ID}인 카드를 찾을 수 없습니다.",
     "ERROR": "카드 정보를 가져오는 중 오류가 발생했습니다. 나중에 다시 시도해주세요\n{ERROR}"
   },


### PR DESCRIPTION
## Summary
- gracefully handle cards without an after-training asset
- mention when a card cannot be trained
- localize new messages for each language

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
Fixed by OpenAI Codex