### PR TITLE
Enable slash commands for all prefix features

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ You can try out this bot with the [official build](https://discord.com/oauth2/au
   * [Configuration](#configuration)
 * [Commands & Usage](#commands--usage)
   * [`/lang` Command](#lang-command)
-  * `^card <ID>`
-  * `^char <ID>`
-  * `^gacha <ID>`
-  * `^help`
+  * `^card`/`/card`
+  * `^char`/`/character`
+  * `^gacha`/`/gacha`
+  * `^help`/`/help`
   * (Future: `^event`, `^song`)
 * [Localization](#localization)
   * [Language Settings Storage](#language-settings-storage)
@@ -30,13 +30,13 @@ You can try out this bot with the [official build](https://discord.com/oauth2/au
 ---
 
 ## Features
-* **Card Lookup** (`^card <ID>`)
+* **Card Lookup** (`^card` or `/card`)
   * Shows a single‐language card title and character name, plus attaches full "normal" and "after-training" card images.
-* **Character Lookup** (`^char <ID>`)
+* **Character Lookup** (`^char` or `/character`)
   * Displays a single‐language character name, band name, and character icon.
-* **Gacha Lookup** (`^gacha <ID>`)
+* **Gacha Lookup** (`^gacha` or `/gacha`)
   * Displays information about a gacha banner.
-* **Help Menu** (`^help`)
+* **Help Menu** (`^help` or `/help`)
   * Lists all available commands and usage instructions, localized.
 * **Slash Command for Language** (`/lang <code>`)
   * Allows per-guild or per-user language selection (ENG, CHS, CHT, JPN, KOR).
@@ -166,12 +166,12 @@ Changes the bot’s language. Usage:
 * **DM Context**:
   Any user may run `/lang <code>` in a DM. This sets their personal language for DM‐only interactions.
 
-### `^card <ID>`
+### `^card <ID>` or `/card <ID>`
 
 Fetches and displays information about a card.
 
 ```
-^card 947
+/card 947
 ```
 
 * **Features**:
@@ -181,12 +181,12 @@ Fetches and displays information about a card.
   * Attaches both the “normal” and “after-training” full-size card images.
   * Replies localized usage, embed title, field names, “not found,” and error messages.
 
-### `^char <ID>`
+### `^char <ID>` or `/character <ID>`
 
 Fetches and displays information about a character.
 
 ```
-^char 35
+/character 35
 ```
 
 * **Features**:
@@ -196,12 +196,12 @@ Fetches and displays information about a character.
   * Attaches the character’s icon image.
   * Replies localized usage, embed title, field name, “not found,” and error messages.
 
-### `^gacha <ID>`
+### `^gacha <ID>` or `/gacha <ID>`
 
 Fetches and displays information about a gacha.
 
 ```
-^gacha 100
+/gacha 100
 ```
 
 * **Features**:
@@ -210,17 +210,17 @@ Fetches and displays information about a gacha.
   * Displays the event period if available.
   * Attaches the banner image when possible.
 
-### `^help`
+### `^help` or `/help`
 
 Shows an embed listing all available commands and their descriptions.
 
 ```
-^help
+/help
 ```
 
 * **Features**:
 
-  * Lists every command (`^card`, `^char`, `^event`, `^gacha`, `^song`, `^help`, `/lang`) with usage and short description.
+  * Lists every command (`^card`/`/card`, `^char`/`/character`, `^event`, `^gacha`/`/gacha`, `^song`, `^help`/`/help`, `/lang`) with usage and short description.
   * All field names and descriptions are pulled from the active language’s textmap.
   * Footer shows the bot’s version.
 

--- a/commands/card.py
+++ b/commands/card.py
@@ -15,6 +15,7 @@ import re
 import aiohttp
 import discord
 from discord.ext import commands
+from discord import app_commands
 
 import bestdori.cards
 import bestdori.characters
@@ -87,8 +88,13 @@ class CardCog(commands.Cog):
         }
     
 
-    @commands.command(name='card', aliases=['check_card', 'card_check'])
-    async def card(self, ctx: commands.Context, card_id: str = None):
+    @commands.hybrid_command(
+        name="card",
+        aliases=["check_card", "card_check"],
+        description="Look up a card by ID",
+    )
+    @app_commands.describe(card_id="Card ID or 'pjsk' prefixed ID")
+    async def card(self, ctx: commands.Context, card_id: str | None = None):
         if ctx.guild:
             lang = language_settings["guild"].get(str(ctx.guild.id), "ENG")
         else:

--- a/commands/character.py
+++ b/commands/character.py
@@ -13,6 +13,7 @@ import io
 import aiohttp
 import discord
 from discord.ext import commands
+from discord import app_commands
 
 import bestdori.characters
 import bestdori.bands
@@ -65,8 +66,13 @@ class CharacterCog(commands.Cog):
 
         return {"name": name, "band": unit_name, "image": image_url}
 
-    @commands.command(name='character', aliases=['char'])
-    async def character(self, ctx: commands.Context, char_id: str = None):
+    @commands.hybrid_command(
+        name="character",
+        aliases=["char"],
+        description="Look up a character by ID",
+    )
+    @app_commands.describe(char_id="Character ID or 'pjsk' prefixed ID")
+    async def character(self, ctx: commands.Context, char_id: str | None = None):
 
         if ctx.guild:
             lang = language_settings["guild"].get(str(ctx.guild.id), "ENG")

--- a/commands/gacha.py
+++ b/commands/gacha.py
@@ -14,6 +14,7 @@ import datetime
 import aiohttp
 import discord
 from discord.ext import commands
+from discord import app_commands
 
 import bestdori.gacha
 import bestdori.cards
@@ -92,8 +93,12 @@ class GachaCog(commands.Cog):
             "pickups": pickups,
         }
 
-    @commands.command(name="gacha")
-    async def gacha(self, ctx: commands.Context, gacha_id: str = None):
+    @commands.hybrid_command(
+        name="gacha",
+        description="Look up a gacha by ID",
+    )
+    @app_commands.describe(gacha_id="Gacha ID or 'pjsk' prefixed ID")
+    async def gacha(self, ctx: commands.Context, gacha_id: str | None = None):
         if ctx.guild:
             lang = language_settings["guild"].get(str(ctx.guild.id), "ENG")
         else:

--- a/commands/help.py
+++ b/commands/help.py
@@ -11,6 +11,7 @@
 
 import discord
 from discord.ext import commands
+from discord import app_commands
 
 from lang_settings import language_settings
 from localisation import get_text
@@ -19,7 +20,7 @@ class HelpCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    @commands.command(name='help')
+    @commands.hybrid_command(name="help", description="Show help information")
     async def help(self, ctx: commands.Context):
         if ctx.guild:
             lang = language_settings["guild"].get(str(ctx.guild.id), "ENG")


### PR DESCRIPTION
## Summary
- make card, character, gacha and help commands hybrid so they work as prefix or slash
- document slash command usage in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f9843ffa88328a7dcbb82f59a4305